### PR TITLE
bff経由で感情分析できるようにした

### DIFF
--- a/bff/emo_api.py
+++ b/bff/emo_api.py
@@ -1,0 +1,18 @@
+import requests
+import json
+
+def post(text: str) -> str:
+  host = "api"
+  port = 8000
+  uri = "inference"
+  url = f"http://{host}:{port}/{uri}"
+  headers = {'Content-Type': 'application/json'}
+  data = {
+    "text": text
+  }
+  response = requests.post(
+    url,
+    headers=headers,
+    json=data
+  )
+  return response.json()

--- a/bff/main.py
+++ b/bff/main.py
@@ -2,6 +2,7 @@ import strawberry
 from fastapi import FastAPI
 from strawberry.fastapi import GraphQLRouter
 from pydantic import BaseModel
+import emo_api
 @strawberry.type
 class Query:
     @strawberry.field
@@ -10,7 +11,6 @@ class Query:
 
 class Item(BaseModel):
     text:str
-    num :int
 
 schema = strawberry.Schema(Query)
 
@@ -21,4 +21,4 @@ app.include_router(graphql_app, prefix="/graphql")
 
 @app.post('/post')
 async def declare_request_body(item: Item):
-    return {"test_message":f"text:{item.text},num:{item.num}"}
+    return emo_api.post(item.text)

--- a/docker/bff/requirements.txt
+++ b/docker/bff/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.89.1
 strawberry-graphql[fastapi]==0.155.4
 pydantic==1.10.4
+requests==2.28.2


### PR DESCRIPTION
# issue番号

close #12  

# 概要

ローカルで`curl  -X POST -H "Content-Type: application/json" -d '{"text": "ほげ"}' http://127.0.0.1:9000/post`を叩くと感情分析の結果が返ってくる

1. bffにpost
2. bffがpostされた内容をそのまま感情分析APIにpost
3. 感情分析APIのレスポンスをそのままレスポンスとしている

# その他(お知らせすること)
emotional_analysis_apiのdocker-compose.cpu.yml(gpuも同様)に以下のように変更を加える

```diff
version: "3"

services:
  api:
    build:
      context: .
      dockerfile: ./docker/cpu/Dockerfile
    volumes:
      - ./app:/app
    expose:
      - 8000
    tty: true
    ipc: host
    labels:
      - com.example.type="gpu"
    command: uvicorn main:app --reload --host 0.0.0.0 --port 8000

+ networks:
+   default:
+      name: emosic_default
+      external: true
```

emo...apiが接続するnetworkを指定しています(難しいので読み飛ばしてもOKです)
詳しくは[docker compose networks](https://docs.docker.jp/compose/networking.html#comopse-use-a-pre-existing-network)