### PR TITLE
SpotyfyAPIのレスポンスを整形して返す

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_STORE
 **/emotional-analysis-api/
 bff/__pycache__
+bff/api_handler/__pycache__

--- a/bff/api_handler/dummy.json
+++ b/bff/api_handler/dummy.json
@@ -1,0 +1,119 @@
+{
+  "seeds": [
+    {
+      "afterFilteringSize": 0,
+      "afterRelinkingSize": 0,
+      "href": "string",
+      "id": "string",
+      "initialPoolSize": 0,
+      "type": "string"
+    }
+  ],
+  "tracks": [
+    {
+      "album": {
+        "album_type": "compilation",
+        "total_tracks": 9,
+        "available_markets": ["CA", "BR", "IT"],
+        "external_urls": {
+          "spotify": "string"
+        },
+        "href": "string",
+        "id": "2up3OPMp9Tb4dAKM2erWXQ",
+        "images": [
+          {
+            "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+            "height": 300,
+            "width": 300
+          }
+        ],
+        "name": "string",
+        "release_date": "1981-12",
+        "release_date_precision": "year",
+        "restrictions": {
+          "reason": "market"
+        },
+        "type": "album",
+        "uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+        "copyrights": [
+          {
+            "text": "string",
+            "type": "string"
+          }
+        ],
+        "external_ids": {
+          "isrc": "string",
+          "ean": "string",
+          "upc": "string"
+        },
+        "genres": ["Egg punk", "Noise rock"],
+        "label": "string",
+        "popularity": 0,
+        "album_group": "compilation",
+        "artists": [
+          {
+            "external_urls": {
+              "spotify": "string"
+            },
+            "href": "string",
+            "id": "string",
+            "name": "string",
+            "type": "artist",
+            "uri": "string"
+          }
+        ]
+      },
+      "artists": [
+        {
+          "external_urls": {
+            "spotify": "string"
+          },
+          "followers": {
+            "href": "string",
+            "total": 0
+          },
+          "genres": ["Prog rock", "Grunge"],
+          "href": "string",
+          "id": "string",
+          "images": [
+            {
+              "url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+              "height": 300,
+              "width": 300
+            }
+          ],
+          "name": "string",
+          "popularity": 0,
+          "type": "artist",
+          "uri": "string"
+        }
+      ],
+      "available_markets": ["string"],
+      "disc_number": 0,
+      "duration_ms": 0,
+      "explicit": true,
+      "external_ids": {
+        "isrc": "string",
+        "ean": "string",
+        "upc": "string"
+      },
+      "external_urls": {
+        "spotify": "string"
+      },
+      "href": "string",
+      "id": "string",
+      "is_playable": true,
+      "linked_from": {},
+      "restrictions": {
+        "reason": "string"
+      },
+      "name": "string",
+      "popularity": 0,
+      "preview_url": "string",
+      "track_number": 0,
+      "type": "track",
+      "uri": "string",
+      "is_local": true
+    }
+  ]
+}

--- a/bff/api_handler/recommendation.py
+++ b/bff/api_handler/recommendation.py
@@ -1,0 +1,94 @@
+"""SpotifyAPIから受け取ったjsonに対応するデータオブジェクト
+
+Get Recommendationsが返すjsonに対応
+https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations
+"""
+
+from typing import List, Dict, Union
+from pydantic import BaseModel
+
+from pydantic import BaseModel
+
+
+class Seed(BaseModel):
+    afterFilteringSize: int
+    afterRelinkingSize: int
+    href: str
+    id: str
+    initialPoolSize: int
+    type: str
+
+
+class Images(BaseModel):
+    url: str
+    height: int
+    width: int
+
+
+class Album(BaseModel):
+    album_type: str
+    total_tracks: int
+    available_markets: List[str]
+    external_urls: Dict[str, str]
+    href: str
+    id: str
+    images: List[Images]
+    name: str
+    release_date: str
+    release_date_precision: str
+    restrictions: Dict[str, str]
+    type: str
+    uri: str
+    copyrights: List[Dict[str, str]]
+    external_ids: Dict[str, str]
+    genres: List[str]
+    label: str
+    popularity: int
+    album_group: str
+    artists: List[Dict[str, Union[str, Dict[str, str]]]]
+
+
+class Followers(BaseModel):
+    href: str
+    total: int
+
+
+class Artist(BaseModel):
+    external_urls: Dict[str, str]
+    followers: Followers
+    genres: List[str]
+    href: str
+    id: str
+    images: List[Images]
+    name: str
+    popularity: int
+    type: str
+    uri: str
+
+
+class Track(BaseModel):
+    album: Album
+    artists: List[Artist]
+    available_markets: List[str]
+    disc_number: int
+    duration_ms: int
+    explicit: bool
+    external_ids: Dict[str, str]
+    external_urls: Dict[str, str]
+    href: str
+    id: str
+    is_playable: bool
+    linked_from: Dict
+    restrictions: Dict[str, str]
+    name: str
+    popularity: int
+    preview_url: str
+    track_number: int
+    type: str
+    uri: str
+    is_local: bool
+
+
+class Recommendation(BaseModel):
+    seeds: List[Seed]
+    tracks: List[Track]

--- a/bff/api_handler/spotify_interface.py
+++ b/bff/api_handler/spotify_interface.py
@@ -1,0 +1,28 @@
+"""SpotifyAPIに対する操作を実装するインターフェース
+
+Get Recommendationsが返すjsonに対応
+https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations
+"""
+import json
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+import os
+from os import path
+
+
+def dummy_APIcall():
+    """仮のjsonレスポンスを返す
+
+    ここのexample:responceを参照
+    https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations
+    """
+
+    json_path = path.join(path.dirname(__file__), 'dummy.json')
+    with open(json_path, 'r') as f:
+        d = json.load(f)
+    print(d)
+    return jsonable_encoder(d)
+
+
+if __name__ == "__main__":
+    dummy_APIcall()

--- a/bff/main.py
+++ b/bff/main.py
@@ -2,6 +2,8 @@ import strawberry
 from fastapi import FastAPI
 from strawberry.fastapi import GraphQLRouter
 from pydantic import BaseModel
+from api_handler.recommendation import Recommendation
+from api_handler.spotify_interface import dummy_APIcall
 
 
 @strawberry.type
@@ -27,3 +29,21 @@ app.include_router(graphql_app, prefix="/graphql")
 @app.post('/post')
 async def declare_request_body(item: Item):
     return {"test_message": f"text:{item.text},num:{item.num}"}
+
+
+@app.post('/recommendation')
+async def test_for_spotify():
+    res = dummy_APIcall()
+    item = Recommendation(**res)
+    album = item.tracks[0].album
+    return {
+        "name": album.name,
+        "uri": album.uri,
+        "image": [
+            {
+                "url": album.images[0].url,
+                "height": album.images[0].height,
+                "width": album.images[0].width
+            }
+        ]
+    }

--- a/bff/main.py
+++ b/bff/main.py
@@ -18,6 +18,12 @@ class Item(BaseModel):
     num: int
 
 
+class EmotionText(BaseModel):
+    """感情分析に噛ませるためのテキスト
+    """
+    text: str
+
+
 schema = strawberry.Schema(Query)
 
 graphql_app = GraphQLRouter(schema)
@@ -32,7 +38,7 @@ async def declare_request_body(item: Item):
 
 
 @app.post('/recommendation')
-async def test_for_spotify():
+async def test_for_spotify(text: EmotionText):
     res = dummy_APIcall()
     item = Recommendation(**res)
     album = item.tracks[0].album

--- a/bff/main.py
+++ b/bff/main.py
@@ -2,15 +2,19 @@ import strawberry
 from fastapi import FastAPI
 from strawberry.fastapi import GraphQLRouter
 from pydantic import BaseModel
+
+
 @strawberry.type
 class Query:
     @strawberry.field
     def hello(self) -> str:
         return "Hello World"
 
+
 class Item(BaseModel):
-    text:str
-    num :int
+    text: str
+    num: int
+
 
 schema = strawberry.Schema(Query)
 
@@ -19,6 +23,7 @@ graphql_app = GraphQLRouter(schema)
 app = FastAPI()
 app.include_router(graphql_app, prefix="/graphql")
 
+
 @app.post('/post')
 async def declare_request_body(item: Item):
-    return {"test_message":f"text:{item.text},num:{item.num}"}
+    return {"test_message": f"text:{item.text},num:{item.num}"}

--- a/rust-app/src/server.rs
+++ b/rust-app/src/server.rs
@@ -30,3 +30,14 @@ pub async fn send_post_to_bff(json: serde_json::Value) -> reqwest::Result<String
         .await?;
     responce.text().await
 }
+async fn reqest_recommendation(text: &str) -> reqwest::Result<String> {
+    let json = serde_json::json!({ "text": text });
+
+    let client = reqwest::Client::new();
+    let responce = client
+        .post("http://bff:9000/recommendation")
+        .json(&json)
+        .send()
+        .await?;
+    responce.text().await
+}


### PR DESCRIPTION
# issue番号
#15
# 概要
`curl -X POST -H 'Content-Type: application/json' -d '{"text":"hello"}' http://localhost:9000/recommendation`を叩くと、整形済みのjsonが返ってきます
server.rsにも、そのPOSTを叩くための関数request_recommendationを実装しています(現段階ではunused)
# その他(お知らせすること)
htmlのフォームから送信されたらbffのPOSTを叩く関数を呼ぶ実装は別のissueで