### PR TITLE
formの値をrust-appで受け取る

### DIFF
--- a/rust-app/Cargo.lock
+++ b/rust-app/Cargo.lock
@@ -1339,6 +1339,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "reqwest",
+ "serde",
  "serde_json",
  "tera",
 ]
@@ -1422,6 +1423,20 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/rust-app/Cargo.toml
+++ b/rust-app/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 tera="1"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }

--- a/rust-app/src/server.rs
+++ b/rust-app/src/server.rs
@@ -1,7 +1,9 @@
 use actix_web::{get, post, web, HttpResponse, Responder};
 use reqwest;
+use serde::Deserialize;
 use serde_json;
 use tera::Tera;
+
 #[get("/")]
 pub async fn hello(templates: web::Data<Tera>) -> impl Responder {
     let view = templates.render("index.html", &tera::Context::new());
@@ -11,10 +13,18 @@ pub async fn hello(templates: web::Data<Tera>) -> impl Responder {
         Err(e) => HttpResponse::InternalServerError().body(e.to_string()),
     }
 }
-#[post("/post")]
-pub async fn post_example(item: web::Json<serde_json::Value>) -> impl Responder {
-    format!("responce is \n",);
-    let res = send_post_to_bff(item.0);
+
+#[derive(Deserialize)]
+struct FormText {
+    text: String,
+}
+
+#[post("/")]
+pub async fn post_example(web::Form(form): web::Form<FormText>) -> impl Responder {
+    let json_string = format!("{{\"text\":\"{}\"}}", form.text);
+    let json_item = serde_json::from_str(&json_string).unwrap();
+
+    let res = send_post_to_bff(json_item);
     match res.await {
         Ok(res) => HttpResponse::Ok().content_type("text/html").body(res),
         Err(e) => HttpResponse::InternalServerError().body(e.to_string()),

--- a/rust-app/templates/index.html
+++ b/rust-app/templates/index.html
@@ -25,7 +25,7 @@
             今のあなたの感情を教えてください
           </h2>
         </div>
-        <form>
+        <form method="POST">
           <div class="grid-cols-12 text-center h-12">
             <input
               class="shadow appearance-none border rounded w-full py-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"


### PR DESCRIPTION
# issue番号
#18 
# 概要
フロントエンドでボタンを押すとpostが送られ、テキストをserde_json::Value型に束縛しています
# その他(お知らせすること)
現状はsend_post_to_bffから返ってくるjsonを生でブラウザに表示します
将来的にはちゃんとしたページをレンダリングする